### PR TITLE
[ENG-39152, examples] SNMPv3 with auth-Priv level SHA authentication …

### DIFF
--- a/development/advanced-development/developing-neds/cli-ned-development.md
+++ b/development/advanced-development/developing-neds/cli-ned-development.md
@@ -583,7 +583,7 @@ list community {
         tailf:info "read only community";
         type string {
             length "1..31";
-            tailf:info "WORD<length:1-31>;;SNMPv1/v2c community string";
+            tailf:info "WORD<length:1-31>;;SNMP access string";
         }
     }
     leaf remote {

--- a/development/advanced-development/developing-neds/snmp-ned.md
+++ b/development/advanced-development/developing-neds/snmp-ned.md
@@ -55,7 +55,7 @@ Finally make sure that the NSO configuration file points to the correct device m
 
 ## Configuring NSO to Speak SNMP Southbound <a href="#d5e120" id="d5e120"></a>
 
-Each managed device is configured with a name, IP address, and port (161 by default), and the SNMP version to use (v1, v2c, or v3).
+Each managed device is configured with a name, IP address, and port (161 by default), and uses SNMPv3 with `auth-priv`.
 
 ```cli
 admin@host# show running-config devices device r3
@@ -66,23 +66,22 @@ device-type snmp version v3 snmp-authgroup my-authgroup
 state admin-state unlocked
 ```
 
-To minimize the necessary configuration, the authentication group concept (see [Authentication Groups](../../../operation-and-usage/operations/nso-device-manager.md#user_guide.devicemanager.authgroups)) is used also for SNMP. A configured managed device of the type `snmp` refers to an SNMP authgroup. An SNMP authgroup contains community strings for SNMP v1 and v2c and USM parameters for SNMP v3.
+To minimize the necessary configuration, the authentication group concept (see [Authentication Groups](../../../operation-and-usage/operations/nso-device-manager.md#user_guide.devicemanager.authgroups)) is used also for SNMP. A configured managed device of the type `snmp` refers to an SNMP authgroup. The SNMP authgroup contains only SNMPv3 USM parameters with `auth-priv`, SHA, and AES.
 
 ```cli
 admin@host# show running-config devices authgroups snmp-group my-authgroup
 
 devices authgroups snmp-group my-authgroup
- default-map community-name public
  umap admin
   usm remote-name admin
   usm security-level auth-priv
-  usm auth md5 remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
-  usm priv des remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm auth sha remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm priv aes remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
  !
 !
 ```
 
-In the example above, when NSO needs to speak to the device `r3`, it sees that the device is of type `snmp`, and that SNMP v3 should be used with authentication parameters from the SNMP authgroup `my-authgroup`. This authgroup maps the local NSO user `admin` to the USM user `admin`, with explicit remote passwords given. These passwords will be localized for each SNMP engine that NSO communicates with. While the passwords above are shown encrypted, when you enter them in the CLI you write them in clear text. Note also that the remote engine ID is not configured; NSO performs a discovery process to find it automatically.
+In the example above, when NSO needs to speak to the device `r3`, it sees that the device is of type `snmp`, and that SNMPv3 `auth-priv` should be used with authentication parameters from the SNMP authgroup `my-authgroup`. This authgroup maps the local NSO user `admin` to the USM user `admin`, with explicit remote passwords given. These passwords will be localized for each SNMP engine that NSO communicates with. While the passwords above are shown encrypted, when you enter them in the CLI you write them in clear text. Note also that the remote engine ID is not configured; NSO performs a discovery process to find it automatically.
 
 No NSO user other than `admin` is mapped by the `authgroup my-authgroup` for SNMP v3.
 

--- a/development/connected-topics/snmp-notification-receiver.md
+++ b/development/connected-topics/snmp-notification-receiver.md
@@ -4,7 +4,7 @@ description: Configure NSO to receive SNMP notifications.
 
 # SNMP Notification Receiver
 
-NSO can act as an SNMP notification receiver (v1, v2c, v3) for its managed devices. The application can register notification handlers and react to the notifications, for example, by mapping SNMP notifications to NSO alarms.
+NSO can act as an SNMP notification receiver for its managed devices. The examples use SNMPv3 `auth-priv` notifications with SHA authentication and AES privacy. The application can register notification handlers and react to the notifications, for example, by mapping SNMP notifications to NSO alarms.
 
 <div data-with-frame="true"><figure><img src="../../.gitbook/assets/snmp-notif.png" alt="" width="563"><figcaption><p>SNMP NED Compile Steps</p></figcaption></figure></div>
 
@@ -29,6 +29,8 @@ The NSO operator must enable the SNMP notification receiver and configure the ad
 The notification reception can be turned on and off using the enabled lead. NSO will listen to notifications at the end points configured in `listen`. There is no need to manually configure the NSO `engine-id`. NSO will do this automatically using the algorithm described in RFC 3411. However, it can be assigned an `engine-id` manually by setting this leaf.
 
 The managed devices must also be configured to send notifications to the NSO addresses.
+
+Configure the sending devices to use SNMPv3 USM with `auth-priv`, SHA authentication, and AES privacy when sending traps or informs to NSO.
 
 NSO silently ignores any notification received from unknown devices. By default, NSO uses the `/devices/device/address` leaf, but this can be overridden by setting `/devices/device/snmp-notification-address`.
 

--- a/development/core-concepts/northbound-apis/nso-snmp-agent.md
+++ b/development/core-concepts/northbound-apis/nso-snmp-agent.md
@@ -4,7 +4,7 @@ description: Description of SNMP agent.
 
 # NSO SNMP Agent
 
-The SNMP agent in NSO is used mainly for monitoring and notifications. It supports SNMPv1, SNMPv2c, and SNMPv3.
+The SNMP agent in NSO is used mainly for monitoring and notifications. This guide covers the SNMPv3 `auth-priv` setup used in the examples, with SHA authentication and AES privacy.
 
 The following standard MIBs are supported by the SNMP agent:
 
@@ -35,16 +35,15 @@ An example session configuring the SNMP agent through the CLI may look like:
 admin@ncs# config
 Entering configuration mode terminal
 admin@ncs(config)# snmp agent udp-port 3457
-admin@ncs(config)# snmp community public name foobaz
-admin@ncs(config-community-public)# commit
+admin@ncs(config)# snmp target monitor usm user-name initial
+admin@ncs(config-target-monitor-usm)# snmp target monitor usm sec-level auth-priv
+admin@ncs(config-target-monitor-usm)# commit
 Commit complete.
-admin@ncs(config-community-public)# top
+admin@ncs(config-target-monitor-usm)# top
 admin@ncs(config)# show full-configuration snmp
 snmp agent enabled
 snmp agent ip    0.0.0.0
 snmp agent udp-port 3457
-snmp agent version v1
-snmp agent version v2c
 snmp agent version v3
 snmp agent engine-id enterprise-number 32473
 snmp agent engine-id from-text testing
@@ -62,11 +61,8 @@ snmp target monitor
  tag      [ monitor ]
  timeout  1500
  retries  3
- v2c sec-name public
-!
-snmp community public
- name     foobaz
- sec-name public
+ usm user-name initial
+ usm sec-level auth-priv
 !
 snmp notify foo
  tag  monitor
@@ -76,24 +72,7 @@ snmp vacm group initial
  member initial
   sec-model [ usm ]
  !
- access usm no-auth-no-priv
-  read-view   internet
-  notify-view internet
- !
- access usm auth-no-priv
-  read-view   internet
-  notify-view internet
- !
  access usm auth-priv
-  read-view   internet
-  notify-view internet
- !
-!
-snmp vacm group public
- member public
-  sec-model [ v1 v2c ]
- !
- access any no-auth-no-priv
   read-view   internet
   notify-view internet
  !
@@ -115,7 +94,7 @@ snmp vacm view restricted
 
 The SNMP agent configuration data is stored in CDB as any other configuration data, but is handled as a transformation between the data shown above and the data stored in the standard MIBs.
 
-If you want to have a default configuration of the SNMP agent, you must provide that in an XML file. The initialization data of the SNMP agent is stored in an XML file that has precisely the same format as CDB initialization XML files, but it is not loaded by CDB, rather it is loaded at first startup by the SNMP agent. The XML file must be called `snmp_init.xml` and it must reside in the load path of NSO. In the NSO distribution, there is such an initialization file in `$NCS_DIR/etc/ncs/snmp/snmp_init.xml`. It is strongly recommended that this file be customized with another engine ID and other community strings and v3 users.
+If you want to have a default configuration of the SNMP agent, you must provide that in an XML file. The initialization data of the SNMP agent is stored in an XML file that has precisely the same format as CDB initialization XML files, but it is not loaded by CDB, rather it is loaded at first startup by the SNMP agent. The XML file must be called `snmp_init.xml` and it must reside in the load path of NSO. In the NSO distribution, there is such an initialization file in `$NCS_DIR/etc/ncs/snmp/snmp_init.xml`. It is strongly recommended that this file be customized with another engine ID and site-specific SNMPv3 users and passwords.
 
 If no `snmp_init.xml` file is found in the load path a default configuration with the agent disabled is loaded. Thus, the easiest way to start NSO without the SNMP agent is to ensure that the directory `$NCS_DIR/etc/ncs/snmp/` is not part of the NSO load path.
 
@@ -223,7 +202,7 @@ The MIB defines separate notifications for every severity level to support SNMP 
 
 ### Using the SNMP Alarm MIB
 
-Alarm Managers should subscribe to the notifications and read the alarm table to synchronize the alarm list. To do this you need an access view that matches the alarm MIB and creates a SNMP target. Default SNMP settings in NSO let you read the alarm MIB with v2c and community public. A target is set up in the following way, (assuming the SNMP Alarm Manager has IP address 192.168.1.1 and wants community string public in the v2c notifications):
+Alarm Managers should subscribe to the notifications and read the alarm table to synchronize the alarm list. To do this you need an access view that matches the alarm MIB and creates an SNMP target. In the examples, the alarm target uses SNMPv3 `auth-priv` with the `initial` user and SHA/AES credentials. A target is set up in the following way, assuming the SNMP Alarm Manager has IP address `192.168.1.1` and is configured with the same SNMPv3 user:
 
 {% code title="Example: Subscribing to SNMP Alarms" %}
 ```bash
@@ -232,7 +211,7 @@ admin@ncs# config
 Entering configuration mode terminal
 admin@ncs(config)# snmp notify monitor type trap tag monitor
 admin@ncs(config-notify-monitor)# snmp target alarm-system ip 192.168.1.1 udp-port 162 \
-        tag monitor v2c sec-name public
+        tag monitor usm user-name initial sec-level auth-priv
 admin@ncs(config-target-alarm-system)# commit
 Commit complete.
 admin@ncs(config-target-alarm-system)# show full-configuration snmp target
@@ -242,7 +221,8 @@ snmp target alarm-system
  tag      [ monitor ]
  timeout  1500
  retries  3
- v2c sec-name public
+ usm user-name initial
+ usm sec-level auth-priv
 !
 snmp target monitor
  ip       127.0.0.1
@@ -250,7 +230,8 @@ snmp target monitor
  tag      [ monitor ]
  timeout  1500
  retries  3
- v2c sec-name public
+ usm user-name initial
+ usm sec-level auth-priv
 !
 admin@ncs(config-target-alarm-system)#
 ```

--- a/operation-and-usage/operations/neds-and-adding-devices.md
+++ b/operation-and-usage/operations/neds-and-adding-devices.md
@@ -75,12 +75,11 @@ devices authgroups group default
  !
 !
 devices authgroups snmp-group default
- default-map community-name public
  umap admin
   usm remote-name admin
   usm security-level auth-priv
-  usm auth md5 remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
-  usm priv des remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm auth sha remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm priv aes remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
  !
 !
 ```
@@ -94,9 +93,7 @@ admin@ncs(config-umap-joe)# commit
 
 This auth group will pass on `joe`'s credentials to the device.
 
-There is a similar structure for SNMP `devices authgroups snmp-group` that supports SNMPv1/v2c, and SNMPv3 authentication.
-
-The SNMP auth group above has a default auth group for non-mapped users.
+There is a similar structure for SNMP `devices authgroups snmp-group` that, in the examples, is used with SNMPv3 `auth-priv`, SHA authentication, and AES privacy.
 
 ## Connecting Devices for Different NED Types <a href="#d5e537" id="d5e537"></a>
 
@@ -180,7 +177,7 @@ admin@ncs(config)# show full-configuration devices device r1
 devices device r1
  address 127.0.0.1
  port    11023
- device-type snmp version v2c
+ device-type snmp version v3
  device-type snmp snmp-authgroup default
  state admin-state unlocked
 !
@@ -230,7 +227,7 @@ Assume that you have a Cisco device that you would like NSO to configure over CL
 
 ```cli
 admin@ncs(config)# devices device c0 live-status-protocol snmp \
-                                device-type snmp version v1 \
+                                device-type snmp version v3 \
                                 snmp-authgroup default mib-group [ snmp ]
 admin@ncs(config-live-status-protocol-snmp)# commit
 
@@ -243,7 +240,7 @@ devices device c0
  authgroup default
  device-type cli ned-id cisco-ios
  live-status-protocol snmp
-  device-type snmp version v1
+  device-type snmp version v3
   device-type snmp snmp-authgroup default
   device-type snmp mib-group [ snmp ]
  !
@@ -266,7 +263,20 @@ devices {
     authgroups {
         snmp-group g1 {
             umap admin {
-                community-name public;
+                usm {
+                    remote-name    admin;
+                    security-level auth-priv;
+                    auth {
+                        sha {
+                            remote-password $4$wIo7Yd068FRwhYYI0d4IDw==;
+                        }
+                    }
+                    priv {
+                        aes {
+                            remote-password $4$wIo7Yd068FRwhYYI0d4IDw==;
+                        }
+                    }
+                }
             }
         }
     }
@@ -278,7 +288,7 @@ devices {
             port 4001;
             device-type {
                 snmp {
-                    version        v2c;
+                    version        v3;
                     snmp-authgroup g1;
                     mib-group      [ m1 ];
                 }

--- a/operation-and-usage/operations/nso-device-manager.md
+++ b/operation-and-usage/operations/nso-device-manager.md
@@ -921,12 +921,11 @@ devices authgroups group default
  !
 !
 devices authgroups snmp-group default
- default-map community-name public
  umap admin
   usm remote-name admin
   usm security-level auth-priv
-  usm auth md5 remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
-  usm priv des remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm auth sha remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm priv aes remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
  !
 !
 ```
@@ -956,12 +955,11 @@ devices authgroups group default
  !
 !
 devices authgroups snmp-group default
- default-map community-name public
  umap admin
   usm remote-name admin
   usm security-level auth-priv
-  usm auth md5 remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
-  usm priv des remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm auth sha remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm priv aes remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
  !
 !
 ```
@@ -1050,12 +1048,11 @@ devices authgroups group default
  !
 !
 devices authgroups snmp-group default
- default-map community-name public
  umap admin
   usm remote-name admin
   usm security-level auth-priv
-  usm auth md5 remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
-  usm priv des remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm auth sha remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
+  usm priv aes remote-password $4$wIo7Yd068FRwhYYI0d4IDw==
  !
 !
 ```
@@ -3507,7 +3504,7 @@ www2  mysub  admin  running  -        -
 
 ## SNMP Notifications <a href="#d5e4074" id="d5e4074"></a>
 
-SNMP Notifications (v1, v2c, v3) can be received by NSO and acted upon. The SNMP receiver is a stand-alone process and by default, all notifications are ignored. IP addresses must be opted in and a handler must be defined to take actions on certain notifications. This can be used to for example listen to configuration change notifications and trigger a log action or a resync for example
+SNMPv3 `auth-priv` notifications can be received by NSO and acted upon. The SNMP receiver is a stand-alone process and by default, all notifications are ignored. IP addresses must be opted in and a handler must be defined to take actions on certain notifications. This can be used to for example listen to configuration change notifications and trigger a log action or a resync for example
 
 These actions are programmed in Java, see the [SNMP Notification Receiver](../../development/connected-topics/snmp-notification-receiver.md) for how to do this.
 

--- a/operation-and-usage/webui/devices.md
+++ b/operation-and-usage/webui/devices.md
@@ -192,9 +192,8 @@ To add a new group:
 3. In the group details page, add users to the newly created group. If a default map is desired for unknown/unmapped users, use the **Set default-map** option.
    1. Click the **Add user** button to bring up the **Add user** overlay window.
    2. Specify the **local-user** and configure the following settings:
-      * **community** (optional): Choose between **community-name** or **community-binary-name**.
       * **remote-user**: Choose between **same-user** or **remote-name** options.
-      * **security-level**: Choose between **no-auth-no-priv**, **auth-no-priv**, or **auth-priv** options. Depending on the **security-level** selection, specify further the required SNMP authentication and privacy parameters, which include the authentication/privacy protocol, key type, and remote password.
+      * **security-level**: Use **auth-priv**. Then configure SHA as the authentication protocol and AES as the privacy protocol, together with the required remote passwords.
    3. Click **Add**. This adds the newly created user to the group and displays it in the list.
 4. Click **Create** **SNMP** **group** to save and finish creating the group.
 


### PR DESCRIPTION
This pull request updates the SNMP agent documentation to focus exclusively on SNMPv3 with authPriv, SHA authentication, and AES privacy. References to SNMPv1 and SNMPv2c, as well as community-based access, have been removed or clarified as deprecated/not used. The guide, configuration examples, and command-line instructions are all revised to reflect this SNMPv3-centric deployment model.